### PR TITLE
Include schlundtech in dns_autodns.sh

### DIFF
--- a/dnsapi/README.md
+++ b/dnsapi/README.md
@@ -680,14 +680,15 @@ And now you can issue certs with:
 acme.sh --issue --dns dns_namesilo --dnssleep 900 -d example.com -d www.example.com
 ```
 
-## 36. Use autoDNS (InternetX)
+## 36. Use autoDNS (InternetX or Schlund Technologies)
 
-[InternetX](https://www.internetx.com/) offers an [xml api](https://help.internetx.com/display/API/AutoDNS+XML-API)  with your standard login credentials, set them like so:
+[InternetX](https://www.internetx.com/) offers an [xml api](https://help.internetx.com/display/API/AutoDNS+XML-API)  with your standard login credentials. You can also use this API for [Schlund Technologies](https://www.schlundtech.de/). Set them like so:
 
 ```
 export AUTODNS_USER="yourusername"
 export AUTODNS_PASSWORD="password"
 export AUTODNS_CONTEXT="context"
+export AUTODNS_API="https://gateway.autodns.com" # or export AUTODNS_API="https://gateway.schlundtech.de"
 ```
 
 Then you can issue your certificates with:
@@ -696,7 +697,7 @@ Then you can issue your certificates with:
 acme.sh --issue --dns dns_autodns -d example.com -d www.example.com
 ```
 
-The `AUTODNS_USER`, `AUTODNS_PASSWORD` and `AUTODNS_CONTEXT` settings will be saved in `~/.acme.sh/account.conf` and will be reused when needed.
+The `AUTODNS_USER`, `AUTODNS_PASSWORD`, `AUTODNS_CONTEXT` and `AUTODNS_API` settings will be saved in `~/.acme.sh/account.conf` and will be reused when needed.
 
 ## 37. Use Azure DNS
 

--- a/dnsapi/dns_autodns.sh
+++ b/dnsapi/dns_autodns.sh
@@ -1,18 +1,17 @@
 #!/usr/bin/env sh
 # -*- mode: sh; tab-width: 2; indent-tabs-mode: s; coding: utf-8 -*-
 
-# This is the InternetX autoDNS xml api wrapper for acme.sh
+# This is the InternetX autoDNS xml api wrapper for acme.sh (and also works with schlundtech.de)
 # Author: auerswald@gmail.com
 # Created: 2018-01-14
 #
 #     export AUTODNS_USER="username"
 #     export AUTODNS_PASSWORD="password"
 #     export AUTODNS_CONTEXT="context"
+#     export AUTODNS_API="https://gateway.autodns.com" (or https://gateway.schlundtech.de)
 #
 # Usage:
 #     acme.sh --issue --dns dns_autodns -d example.com
-
-AUTODNS_API="https://gateway.autodns.com"
 
 # Arguments:
 #   txtdomain
@@ -24,15 +23,17 @@ dns_autodns_add() {
   AUTODNS_USER="${AUTODNS_USER:-$(_readaccountconf_mutable AUTODNS_USER)}"
   AUTODNS_PASSWORD="${AUTODNS_PASSWORD:-$(_readaccountconf_mutable AUTODNS_PASSWORD)}"
   AUTODNS_CONTEXT="${AUTODNS_CONTEXT:-$(_readaccountconf_mutable AUTODNS_CONTEXT)}"
+  AUTODNS_API="${AUTODNS_API:-$(_readaccountconf_mutable AUTODNS_API)}"
 
-  if [ -z "$AUTODNS_USER" ] || [ -z "$AUTODNS_CONTEXT" ] || [ -z "$AUTODNS_PASSWORD" ]; then
-    _err "You don't specify autodns user, password and context."
+  if [ -z "$AUTODNS_USER" ] || [ -z "$AUTODNS_CONTEXT" ] || [ -z "$AUTODNS_PASSWORD" ] || [ -z "$AUTODNS_API" ]; then
+    _err "You didn't specify autodns user, password, context or api."
     return 1
   fi
 
   _saveaccountconf_mutable AUTODNS_USER "$AUTODNS_USER"
   _saveaccountconf_mutable AUTODNS_PASSWORD "$AUTODNS_PASSWORD"
   _saveaccountconf_mutable AUTODNS_CONTEXT "$AUTODNS_CONTEXT"
+  _saveaccountconf_mutable AUTODNS_API "$AUTODNS_API"
 
   _debug "First detect the root zone"
 
@@ -67,9 +68,10 @@ dns_autodns_rm() {
   AUTODNS_USER="${AUTODNS_USER:-$(_readaccountconf_mutable AUTODNS_USER)}"
   AUTODNS_PASSWORD="${AUTODNS_PASSWORD:-$(_readaccountconf_mutable AUTODNS_PASSWORD)}"
   AUTODNS_CONTEXT="${AUTODNS_CONTEXT:-$(_readaccountconf_mutable AUTODNS_CONTEXT)}"
+  AUTODNS_API="${AUTODNS_API:-$(_readaccountconf_mutable AUTODNS_API)}"
 
-  if [ -z "$AUTODNS_USER" ] || [ -z "$AUTODNS_CONTEXT" ] || [ -z "$AUTODNS_PASSWORD" ]; then
-    _err "You don't specify autodns user, password and context."
+  if [ -z "$AUTODNS_USER" ] || [ -z "$AUTODNS_CONTEXT" ] || [ -z "$AUTODNS_PASSWORD" ] || [ -z "$AUTODNS_API" ]; then
+    _err "You didn't specify autodns user, password, context or api."
     return 1
   fi
 


### PR DESCRIPTION
As mentioned in [this comment](https://github.com/Neilpang/acme.sh/pull/976#issuecomment-379898107), this PR outsources the AUTODNS_API, so one can use the API for InternetX and Schlund Technologies (and also updates the documentation).